### PR TITLE
fix: handle missing project scope in Kanban seeding

### DIFF
--- a/scripts/create-kanban-issues.cjs
+++ b/scripts/create-kanban-issues.cjs
@@ -229,16 +229,21 @@ for (const ticket of tickets) {
     console.log(`[created] ${ticket.key} -> ${issueUrl}`);
   }
 
-  runGh([
-    'project',
-    'item-add',
-    String(projectNumber),
-    '--owner',
-    owner,
-    '--url',
-    issueUrl
-  ]);
-  console.log(`[project] added ${ticket.key} to project #${projectNumber}`);
+  try {
+    runGh([
+      'project',
+      'item-add',
+      String(projectNumber),
+      '--owner',
+      owner,
+      '--url',
+      issueUrl
+    ]);
+    console.log(`[project] added ${ticket.key} to project #${projectNumber}`);
+  } catch (error) {
+    console.warn(`[project] failed to add ${ticket.key}: ${error.message}`);
+    console.warn('Tip: run `gh auth refresh -h github.com -s project` and rerun this script.');
+  }
 }
 
 console.log('Done.');


### PR DESCRIPTION
## Summary
- make SG ticket seeding resilient when project scope is missing
- continue creating issues even if project item add fails
- print actionable remediation command: gh auth refresh -h github.com -s project

## Why
gh project item-add can fail when local token is missing project scope. This change prevents partial ticket generation failures.

## Validation
- executed GH_PROJECT_NUMBER=12 node scripts/create-kanban-issues.cjs
- confirmed SG-0001..SG-0010 issues created
- confirmed project #12 contains all SG tickets
