### PR TITLE
test: SG-0004 billing and payment contract smoke suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This suite currently targets:
 - root endpoint access control
 - society onboarding through root APIs
 - admin authentication and protected endpoint access
+- OpenAPI-driven billing/payment smoke coverage
 - admin refresh token rotation (`/auth/refresh` and `/auth/refresh-token`)
 - session invalidation on logout
 - session invalidation on password change
@@ -42,10 +43,13 @@ ShieldGuard/
 │   └── utils/
 │       ├── containerDiagnostics.js
 │       ├── dataFactory.js
+│       ├── openApiContract.js
 │       ├── polling.js
 │       ├── rootAuth.js
 │       └── rootCredential.js
 └── tests/
+    ├── billing/
+    │   └── billing-payments-contract-smoke.e2e.test.js
     ├── auth/
     │   ├── admin-auth-session.e2e.test.js
     │   ├── root-auth.e2e.test.js
@@ -103,6 +107,12 @@ Run raw Jest only (without pre/post container diagnostics):
 npm run test:e2e:raw
 ```
 
+Run only billing/payment OpenAPI smoke checks:
+
+```bash
+npm run test:e2e:billing
+```
+
 ## Crash Triage Workflow
 
 If SHIELD becomes unstable during test runs:
@@ -154,6 +164,16 @@ If SHIELD becomes unstable during test runs:
 - `allows onboarded admin login and protected route access in tenant scope`
   - Validates `/users` and `/users/{id}` using newly onboarded admin credentials.
   - In strict verification-gated environments, verifies admin login is rejected because onboarding is blocked.
+
+### `billing-payments-contract-smoke.e2e.test.js`
+
+- `discovers billing/payment smoke endpoints from OpenAPI`
+  - Reads SHIELD OpenAPI spec from the SHIELD repository and derives smoke endpoint list.
+- `rejects unauthenticated access on protected billing/payment endpoints`
+  - Verifies unauthorized requests on discovered endpoints return `401` or `403`.
+- `returns contract-aligned responses for root-authenticated billing/payment smoke calls`
+  - Verifies root-authenticated smoke calls return expected status and API envelope.
+  - Emits endpoint-specific mismatch summaries when status/envelope diverge from contract expectations.
 
 ## Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "supertest": "^7.1.1"
+        "supertest": "^7.1.1",
+        "yaml": "^2.8.1"
       },
       "devDependencies": {
         "jest": "^29.7.0"
@@ -4092,6 +4093,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "npm run test:e2e",
     "test:e2e": "node scripts/run-e2e-with-diagnostics.cjs",
     "test:e2e:raw": "jest --runInBand --config jest.config.cjs",
+    "test:e2e:billing": "jest --runInBand --config jest.config.cjs tests/billing/billing-payments-contract-smoke.e2e.test.js",
     "test:e2e:watch": "jest --watch --config jest.config.cjs",
     "shield:start": "node scripts/shield-runtime.cjs start",
     "shield:stop": "node scripts/shield-runtime.cjs stop",
@@ -17,7 +18,8 @@
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "supertest": "^7.1.1"
+    "supertest": "^7.1.1",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "jest": "^29.7.0"

--- a/src/utils/openApiContract.js
+++ b/src/utils/openApiContract.js
@@ -1,0 +1,67 @@
+const fs = require('fs')
+const path = require('path')
+const YAML = require('yaml')
+
+const BILLING_PAYMENT_PATH_PREFIXES = [
+  '/billing/',
+  '/billing-cycles',
+  '/maintenance-charges',
+  '/special-assessments',
+  '/invoices',
+  '/payment-reminders',
+  '/late-fee-rules',
+  '/payments'
+]
+
+function loadOpenApiSpec(projectDir) {
+  const openApiPath = path.resolve(projectDir, 'src/main/resources/openapi.yml')
+  if (!fs.existsSync(openApiPath)) {
+    throw new Error(`OpenAPI spec not found at ${openApiPath}`)
+  }
+
+  const raw = fs.readFileSync(openApiPath, 'utf8')
+  const spec = YAML.parse(raw)
+  if (!spec?.paths) {
+    throw new Error(`OpenAPI spec at ${openApiPath} does not contain a paths section`)
+  }
+
+  return {
+    openApiPath,
+    spec
+  }
+}
+
+function isBillingPaymentPath(pathValue) {
+  return BILLING_PAYMENT_PATH_PREFIXES.some((prefix) => {
+    if (prefix.endsWith('/')) {
+      return pathValue.startsWith(prefix)
+    }
+    return pathValue === prefix || pathValue.startsWith(`${prefix}/`)
+  })
+}
+
+function discoverBillingPaymentGetSmokePaths(spec) {
+  const paths = Object.entries(spec.paths || {})
+    .filter(([pathValue]) => isBillingPaymentPath(pathValue))
+    .filter(([pathValue, operationMap]) => {
+      if (pathValue.includes('{')) {
+        return false
+      }
+
+      const getOperation = operationMap?.get
+      if (!getOperation) {
+        return false
+      }
+
+      return Boolean(getOperation.responses?.['200'])
+    })
+    .map(([pathValue]) => pathValue)
+    .sort()
+
+  return [...new Set(paths)]
+}
+
+module.exports = {
+  loadOpenApiSpec,
+  discoverBillingPaymentGetSmokePaths
+}

--- a/tests/billing/billing-payments-contract-smoke.e2e.test.js
+++ b/tests/billing/billing-payments-contract-smoke.e2e.test.js
@@ -1,0 +1,95 @@
+const { AbstractApiTest } = require('../../src/core/abstractApiTest')
+const { ensureRootReady } = require('../../src/utils/rootAuth')
+const { discoverBillingPaymentGetSmokePaths, loadOpenApiSpec } = require('../../src/utils/openApiContract')
+
+const ROOT_AUTH_ALLOWED_STATUSES_BY_PATH = {
+  '/billing-cycles/current': [200, 404]
+}
+
+function allowedRootStatuses(contractPath) {
+  return ROOT_AUTH_ALLOWED_STATUSES_BY_PATH[contractPath] || [200]
+}
+
+function assertNoContractMismatches(title, mismatches) {
+  if (!mismatches.length) {
+    return
+  }
+
+  const details = mismatches
+    .map((item) => `- ${item.method} ${item.path}: expected ${item.expected}, got ${item.actual}`)
+    .join('\n')
+
+  throw new Error(`${title}\n${details}`)
+}
+
+describe('Billing and payments OpenAPI contract smoke', () => {
+  const suite = new AbstractApiTest()
+  let rootSession
+  let contractSource
+  let contractPaths = []
+
+  beforeAll(async () => {
+    await suite.setup()
+    rootSession = await ensureRootReady(suite.api, suite.config)
+
+    const loaded = loadOpenApiSpec(suite.config.projectDir)
+    contractSource = loaded.openApiPath
+    contractPaths = discoverBillingPaymentGetSmokePaths(loaded.spec)
+  })
+
+  afterAll(async () => {
+    await suite.teardown()
+  })
+
+  it('discovers billing/payment smoke endpoints from OpenAPI', () => {
+    expect(contractSource).toContain('openapi.yml')
+    expect(contractPaths.length).toBeGreaterThan(0)
+  })
+
+  it('rejects unauthenticated access on protected billing/payment endpoints', async () => {
+    const mismatches = []
+
+    for (const contractPath of contractPaths) {
+      const response = await suite.api.get(`/api/v1${contractPath}`)
+      if (![401, 403].includes(response.status)) {
+        mismatches.push({
+          method: 'GET',
+          path: contractPath,
+          expected: '401 or 403',
+          actual: response.status
+        })
+      }
+    }
+
+    assertNoContractMismatches('Billing/payment auth boundary mismatches', mismatches)
+  })
+
+  it('returns contract-aligned responses for root-authenticated billing/payment smoke calls', async () => {
+    const mismatches = []
+
+    for (const contractPath of contractPaths) {
+      const response = await suite.api.get(`/api/v1${contractPath}`, rootSession.accessToken)
+      const allowedStatuses = allowedRootStatuses(contractPath)
+      if (!allowedStatuses.includes(response.status)) {
+        mismatches.push({
+          method: 'GET',
+          path: contractPath,
+          expected: allowedStatuses.join(' or '),
+          actual: response.status
+        })
+        continue
+      }
+
+      if (response.status === 200 && response.body?.success !== true) {
+        mismatches.push({
+          method: 'GET',
+          path: contractPath,
+          expected: 'response.body.success=true',
+          actual: `response.body.success=${response.body?.success}`
+        })
+      }
+    }
+
+    assertNoContractMismatches('Billing/payment contract mismatches', mismatches)
+  })
+})


### PR DESCRIPTION
## Summary\n- add OpenAPI contract loader for SHIELD spec\n- add billing/payment smoke suite discovered from OpenAPI paths\n- enforce auth-boundary checks (401/403) on protected endpoints\n- enforce root-authenticated contract status/envelope checks with endpoint-level mismatch summaries\n- add dedicated npm script and README documentation\n\n## Validation\n- SHIELD_ROOT_PASSWORD=*** npm run test:e2e:billing\n- SHIELD_ROOT_PASSWORD=*** npm run test:e2e:raw