### PR TITLE
test: SG-0005 visitor and gate pass end-to-end suite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,8 @@ SHIELD_ROOT_CREDENTIAL_FILE=../root-bootstrap-credential.txt
 # Used only when root password change is required by SHIELD.
 SHIELD_ROOT_EMAIL=root@shield.local
 SHIELD_ROOT_MOBILE=+911234567890
+
+# Optional pre-provisioned tenant admin credentials.
+# Useful when root onboarding is intentionally blocked in strict/prod-like environments.
+SHIELD_ADMIN_EMAIL=
+SHIELD_ADMIN_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ ShieldGuard/
     │   ├── admin-auth-session.e2e.test.js
     │   ├── root-auth.e2e.test.js
     │   └── root-bootstrap-hardening.e2e.test.js
-    └── onboarding/
-        └── tenant-onboarding.e2e.test.js
+    ├── onboarding/
+    │   └── tenant-onboarding.e2e.test.js
+    └── visitor/
+        └── visitor-gatepass-flows.e2e.test.js
 ```
 
 ## Environment Configuration
@@ -74,6 +76,8 @@ Important variables:
 | `SHIELD_ENV_FILE` | SHIELD env file path consumed by `run.sh` (`../dev.env` or `../prod.env`). |
 | `SHIELD_ROOT_PASSWORD` | Root password. If empty, ShieldGuard reads bootstrap credential file. |
 | `SHIELD_ROOT_CREDENTIAL_FILE` | Path to `root-bootstrap-credential.txt`. |
+| `SHIELD_ADMIN_EMAIL` | Optional tenant admin email for suites that need tenant-scoped role testing. |
+| `SHIELD_ADMIN_PASSWORD` | Optional tenant admin password for strict environments where root onboarding is blocked. |
 
 ## How Runtime Boot Works
 
@@ -111,6 +115,12 @@ Run only billing/payment OpenAPI smoke checks:
 
 ```bash
 npm run test:e2e:billing
+```
+
+Run only visitor/gate-pass scenario checks:
+
+```bash
+npm run test:e2e:visitor
 ```
 
 ## Crash Triage Workflow
@@ -174,6 +184,15 @@ If SHIELD becomes unstable during test runs:
 - `returns contract-aligned responses for root-authenticated billing/payment smoke calls`
   - Verifies root-authenticated smoke calls return expected status and API envelope.
   - Emits endpoint-specific mismatch summaries when status/envelope diverge from contract expectations.
+
+### `visitor-gatepass-flows.e2e.test.js`
+
+- `runs resident-to-security gate workflow with explicit role boundaries`
+  - Covers resident pass creation, security-only entry/exit logging, and final pass status transitions.
+  - Validates resident cannot log visitor entry while security can.
+  - In strict environments where root onboarding is blocked, emits actionable setup guidance for `SHIELD_ADMIN_EMAIL` and `SHIELD_ADMIN_PASSWORD`.
+- `blocks unauthenticated visitor pass creation requests`
+  - Verifies unauthenticated callers cannot create visitor passes.
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "node scripts/run-e2e-with-diagnostics.cjs",
     "test:e2e:raw": "jest --runInBand --config jest.config.cjs",
     "test:e2e:billing": "jest --runInBand --config jest.config.cjs tests/billing/billing-payments-contract-smoke.e2e.test.js",
+    "test:e2e:visitor": "jest --runInBand --config jest.config.cjs tests/visitor/visitor-gatepass-flows.e2e.test.js",
     "test:e2e:watch": "jest --watch --config jest.config.cjs",
     "shield:start": "node scripts/shield-runtime.cjs start",
     "shield:stop": "node scripts/shield-runtime.cjs stop",

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -52,7 +52,9 @@ function loadConfig() {
     rootPassword: process.env.SHIELD_ROOT_PASSWORD || '',
     rootCredentialFilePath: credentialFilePath,
     rootEmail: process.env.SHIELD_ROOT_EMAIL || 'root@shield.local',
-    rootMobile: process.env.SHIELD_ROOT_MOBILE || '+911234567890'
+    rootMobile: process.env.SHIELD_ROOT_MOBILE || '+911234567890',
+    adminEmail: process.env.SHIELD_ADMIN_EMAIL || '',
+    adminPassword: process.env.SHIELD_ADMIN_PASSWORD || ''
   };
 }
 

--- a/tests/visitor/visitor-gatepass-flows.e2e.test.js
+++ b/tests/visitor/visitor-gatepass-flows.e2e.test.js
@@ -1,0 +1,180 @@
+const { AbstractApiTest } = require('../../src/core/abstractApiTest')
+const { createStrongPassword, randomSuffix } = require('../../src/utils/dataFactory')
+const { createUnit, loginWithEmail, onboardSocietyWithAdmin } = require('../../src/utils/onboarding')
+
+function ensureExpectedStatus(response, expectedStatuses, method, path) {
+  if (expectedStatuses.includes(response.status)) {
+    return
+  }
+
+  throw new Error(
+    `${method} ${path} expected ${expectedStatuses.join(' or ')}, got ${response.status} (${response.body?.message || 'no message'})`
+  )
+}
+
+describe('Visitor and gate pass end-to-end scenarios', () => {
+  const suite = new AbstractApiTest()
+  const actorContext = {
+    setupBlockedReason: null
+  }
+
+  async function createUser(role, unitId, accessToken) {
+    const suffix = randomSuffix().replace(/[^0-9]/g, '')
+    const password = createStrongPassword(role)
+    const response = await suite.api.post(
+      '/api/v1/users',
+      {
+        unitId,
+        name: `${role} User ${suffix}`,
+        email: `${role.toLowerCase()}.${suffix}@shieldguard.test`,
+        phone: `+9198${suffix.slice(-8)}`,
+        password,
+        role
+      },
+      accessToken
+    )
+    ensureExpectedStatus(response, [200], 'POST', '/api/v1/users')
+
+    return {
+      user: response.body.data,
+      credentials: {
+        email: response.body.data.email,
+        password
+      }
+    }
+  }
+
+  beforeAll(async () => {
+    await suite.setup()
+
+    if (suite.config.adminEmail && suite.config.adminPassword) {
+      actorContext.adminCredentials = {
+        email: suite.config.adminEmail,
+        password: suite.config.adminPassword
+      }
+      actorContext.adminSession = await loginWithEmail(
+        suite.api,
+        suite.config.adminEmail,
+        suite.config.adminPassword
+      )
+    } else {
+      const onboarding = await onboardSocietyWithAdmin(suite.api, suite.config)
+      if (onboarding.onboardingBlocked) {
+        actorContext.setupBlockedReason =
+          `${onboarding.onboardingBlockedReason || 'Tenant admin onboarding unavailable.'} ` +
+          'Set SHIELD_ADMIN_EMAIL and SHIELD_ADMIN_PASSWORD in ShieldGuard/.env for SG-0005 execution in strict environments.'
+        return
+      }
+
+      actorContext.adminCredentials = onboarding.adminCredentials
+      actorContext.adminSession = onboarding.adminSession
+    }
+
+    actorContext.unit = await createUnit(suite.api, actorContext.adminSession.accessToken, {
+      block: 'GATE',
+      unitNumber: `G-${randomSuffix().slice(-4)}`
+    })
+
+    const ownerActor = await createUser('OWNER', actorContext.unit.id, actorContext.adminSession.accessToken)
+    const securityActor = await createUser('SECURITY', actorContext.unit.id, actorContext.adminSession.accessToken)
+
+    actorContext.owner = {
+      ...ownerActor,
+      session: await loginWithEmail(suite.api, ownerActor.credentials.email, ownerActor.credentials.password)
+    }
+    actorContext.security = {
+      ...securityActor,
+      session: await loginWithEmail(suite.api, securityActor.credentials.email, securityActor.credentials.password)
+    }
+  })
+
+  afterAll(async () => {
+    await suite.teardown()
+  })
+
+  it('runs resident-to-security gate workflow with explicit role boundaries', async () => {
+    if (actorContext.setupBlockedReason) {
+      expect(actorContext.setupBlockedReason.toLowerCase()).toContain('shield_admin_email')
+      expect(actorContext.setupBlockedReason.toLowerCase()).toContain('verification')
+      return
+    }
+
+    const validFrom = new Date(Date.now() + 5 * 60 * 1000)
+    const validTo = new Date(validFrom.getTime() + 2 * 60 * 60 * 1000)
+    const passCreateResponse = await suite.api.post(
+      '/api/v1/visitor-passes/create',
+      {
+        unitId: actorContext.unit.id,
+        visitorName: 'Ravi Kumar',
+        vehicleNumber: 'GJ01AB1234',
+        validFrom: validFrom.toISOString(),
+        validTo: validTo.toISOString(),
+        visitDate: validFrom.toISOString().slice(0, 10),
+        purpose: 'Family visit',
+        numberOfPersons: 2
+      },
+      actorContext.owner.session.accessToken
+    )
+    ensureExpectedStatus(passCreateResponse, [200], 'POST', '/api/v1/visitor-passes/create')
+    const visitorPass = passCreateResponse.body.data
+    expect(visitorPass.id).toBeTruthy()
+
+    const residentEntryAttempt = await suite.api.post(
+      '/api/v1/visitor-logs/entry',
+      {
+        visitorPassId: visitorPass.id,
+        entryGate: 'Gate-1'
+      },
+      actorContext.owner.session.accessToken
+    )
+    ensureExpectedStatus(residentEntryAttempt, [403], 'POST', '/api/v1/visitor-logs/entry')
+
+    const securityEntry = await suite.api.post(
+      '/api/v1/visitor-logs/entry',
+      {
+        visitorPassId: visitorPass.id,
+        entryGate: 'Gate-1'
+      },
+      actorContext.security.session.accessToken
+    )
+    ensureExpectedStatus(securityEntry, [200], 'POST', '/api/v1/visitor-logs/entry')
+    expect(securityEntry.body.data.visitorPassId).toEqual(visitorPass.id)
+    expect(securityEntry.body.data.exitTime).toBeNull()
+
+    const currentlyInside = await suite.api.get(
+      '/api/v1/visitor-logs/currently-inside',
+      actorContext.security.session.accessToken
+    )
+    ensureExpectedStatus(currentlyInside, [200], 'GET', '/api/v1/visitor-logs/currently-inside')
+    const insideLogIds = (currentlyInside.body?.data?.content || []).map((log) => log.visitorPassId)
+    expect(insideLogIds).toContain(visitorPass.id)
+
+    const securityExit = await suite.api.post(
+      '/api/v1/visitor-logs/exit',
+      {
+        visitorPassId: visitorPass.id,
+        exitGate: 'Gate-1'
+      },
+      actorContext.security.session.accessToken
+    )
+    ensureExpectedStatus(securityExit, [200], 'POST', '/api/v1/visitor-logs/exit')
+    expect(securityExit.body.data.exitTime).toBeTruthy()
+
+    const passAfterExitResponse = await suite.api.get(
+      `/api/v1/visitor-passes/${visitorPass.id}`,
+      actorContext.security.session.accessToken
+    )
+    ensureExpectedStatus(passAfterExitResponse, [200], 'GET', '/api/v1/visitor-passes/{id}')
+    expect(passAfterExitResponse.body.data.status).toBe('USED')
+  })
+
+  it('blocks unauthenticated visitor pass creation requests', async () => {
+    const response = await suite.api.post('/api/v1/visitor-passes/create', {
+      unitId: actorContext.unit?.id || '00000000-0000-0000-0000-000000000001',
+      visitorName: 'Unauthorized Visitor',
+      validFrom: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      validTo: new Date(Date.now() + 70 * 60 * 1000).toISOString()
+    })
+    ensureExpectedStatus(response, [401, 403], 'POST', '/api/v1/visitor-passes/create')
+  })
+})


### PR DESCRIPTION
## Summary\n- add SG-0005 visitor/gate-pass real-world scenario suite\n- validate resident vs security role boundary (resident blocked from entry logging, security allowed)\n- validate full pass lifecycle transition through entry/exit to USED state\n- add unauthenticated boundary check for visitor-pass creation\n- add optional tenant-admin env wiring for strict environments\n\n## Validation\n- SHIELD_ROOT_PASSWORD=*** npm run test:e2e:visitor\n- SHIELD_ROOT_PASSWORD=*** npm run test:e2e:raw