### PR TITLE
SG-0001: Add OTP and lockout auth E2E suite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,13 @@ SHIELD_ROOT_MOBILE=+911234567890
 # Useful when root onboarding is intentionally blocked in strict/prod-like environments.
 SHIELD_ADMIN_EMAIL=
 SHIELD_ADMIN_PASSWORD=
+
+# Optional SG-0001 OTP/lockout controls.
+# If SHIELD_OTP_TEST_CODE is unset, ShieldGuard can attempt local DB override via docker exec + psql.
+SHIELD_OTP_TEST_CODE=
+SHIELD_LOCAL_POSTGRES_CONTAINER=
+SHIELD_POSTGRES_DB=shield
+SHIELD_POSTGRES_USER=shield
+SHIELD_LOGIN_OTP_MAX_ATTEMPTS=5
+SHIELD_USER_LOCKOUT_MAX_FAILED_ATTEMPTS=5
+SHIELD_USER_LOCKOUT_DURATION_MINUTES=30

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ShieldGuard/
     │   └── billing-payments-contract-smoke.e2e.test.js
     ├── auth/
     │   ├── admin-auth-session.e2e.test.js
+    │   ├── otp-lockout.e2e.test.js
     │   ├── root-auth.e2e.test.js
     │   └── root-bootstrap-hardening.e2e.test.js
     ├── onboarding/
@@ -80,6 +81,10 @@ Important variables:
 | `SHIELD_ROOT_CREDENTIAL_FILE` | Path to `root-bootstrap-credential.txt`. |
 | `SHIELD_ADMIN_EMAIL` | Optional tenant admin email for suites that need tenant-scoped role testing. |
 | `SHIELD_ADMIN_PASSWORD` | Optional tenant admin password for strict environments where root onboarding is blocked. |
+| `SHIELD_OTP_TEST_CODE` | Optional OTP code override when your environment exposes a fixed test OTP. |
+| `SHIELD_LOCAL_POSTGRES_CONTAINER` | Optional explicit postgres container name for SG-0001 local DB helper. |
+| `SHIELD_POSTGRES_DB` | DB name used by SG-0001 local DB helper (`shield` by default). |
+| `SHIELD_POSTGRES_USER` | DB user used by SG-0001 local DB helper (`shield` by default). |
 
 ## How Runtime Boot Works
 
@@ -123,6 +128,18 @@ Run only visitor/gate-pass scenario checks:
 
 ```bash
 npm run test:e2e:visitor
+```
+
+Run auth-focused suites (includes OTP/lockout):
+
+```bash
+npm run test:e2e:auth
+```
+
+Run only OTP and lockout hardening checks:
+
+```bash
+npm run test:e2e:auth-otp-lockout
 ```
 
 Run only asset/complaint workflow checks:
@@ -173,6 +190,18 @@ If SHIELD becomes unstable during test runs:
   - Calls `/auth/change-password`.
   - Verifies old refresh token fails and old password login fails.
   - Verifies login succeeds with the new password.
+
+### `otp-lockout.e2e.test.js`
+
+- `sends OTP login challenge with stable response shape`
+  - Verifies challenge token structure, destination masking behavior, and expiry field presence.
+- `verifies OTP success path and rejects challenge replay`
+  - Verifies one-time OTP challenge semantics and replay rejection.
+  - Supports either `SHIELD_OTP_TEST_CODE` or local Postgres metadata override for deterministic execution.
+- `enforces invalid OTP attempt limits and challenge invalidation`
+  - Verifies invalid OTP attempts are rejected and challenge is invalidated after max attempts.
+- `locks account after failed password attempts and validates recovery path`
+  - Verifies lockout after threshold of wrong password attempts and validates recovery login path.
 
 ### `tenant-onboarding.e2e.test.js`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shieldguard",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "dotenv": "^16.4.5",
         "supertest": "^7.1.1",
         "yaml": "^2.8.1"
@@ -1260,6 +1261,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "npm run test:e2e",
     "test:e2e": "node scripts/run-e2e-with-diagnostics.cjs",
     "test:e2e:raw": "jest --runInBand --config jest.config.cjs",
+    "test:e2e:auth": "jest --runInBand --config jest.config.cjs tests/auth",
+    "test:e2e:auth-otp-lockout": "jest --runInBand --config jest.config.cjs tests/auth/otp-lockout.e2e.test.js",
     "test:e2e:billing": "jest --runInBand --config jest.config.cjs tests/billing/billing-payments-contract-smoke.e2e.test.js",
     "test:e2e:asset-complaint": "jest --runInBand --config jest.config.cjs tests/asset-complaint/asset-complaint-workflows.e2e.test.js",
     "test:e2e:visitor": "jest --runInBand --config jest.config.cjs tests/visitor/visitor-gatepass-flows.e2e.test.js",
@@ -19,6 +21,7 @@
     "shield:inspect": "node scripts/inspect-containers.cjs --logs"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "dotenv": "^16.4.5",
     "supertest": "^7.1.1",
     "yaml": "^2.8.1"

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -54,7 +54,14 @@ function loadConfig() {
     rootEmail: process.env.SHIELD_ROOT_EMAIL || 'root@shield.local',
     rootMobile: process.env.SHIELD_ROOT_MOBILE || '+911234567890',
     adminEmail: process.env.SHIELD_ADMIN_EMAIL || '',
-    adminPassword: process.env.SHIELD_ADMIN_PASSWORD || ''
+    adminPassword: process.env.SHIELD_ADMIN_PASSWORD || '',
+    otpTestCode: process.env.SHIELD_OTP_TEST_CODE || '',
+    localPostgresContainer: process.env.SHIELD_LOCAL_POSTGRES_CONTAINER || '',
+    postgresDb: process.env.SHIELD_POSTGRES_DB || 'shield',
+    postgresUser: process.env.SHIELD_POSTGRES_USER || 'shield',
+    loginOtpMaxAttempts: parseInteger(process.env.SHIELD_LOGIN_OTP_MAX_ATTEMPTS, 5),
+    userLockoutMaxFailedAttempts: parseInteger(process.env.SHIELD_USER_LOCKOUT_MAX_FAILED_ATTEMPTS, 5),
+    userLockoutDurationMinutes: parseInteger(process.env.SHIELD_USER_LOCKOUT_DURATION_MINUTES, 30)
   };
 }
 

--- a/src/utils/localDbTestHelpers.js
+++ b/src/utils/localDbTestHelpers.js
@@ -1,0 +1,169 @@
+const { execFileSync } = require('child_process')
+const bcrypt = require('bcryptjs')
+
+function toTitleProxy(proxy) {
+  const normalized = String(proxy || '').toLowerCase()
+  if (normalized === 'haproxy') {
+    return 'HaProxy'
+  }
+  if (normalized === 'nginx') {
+    return 'Nginx'
+  }
+  return proxy || 'HaProxy'
+}
+
+function composeProjectName(config) {
+  return `system${config.instances}nodes${toTitleProxy(config.proxy)}`.toLowerCase()
+}
+
+function runDocker(args) {
+  return execFileSync('docker', args, { encoding: 'utf8' }).trim()
+}
+
+function detectPostgresContainer(config) {
+  if (config.localPostgresContainer) {
+    return config.localPostgresContainer
+  }
+
+  try {
+    const lines = runDocker(['ps', '--format', '{{.Names}}\t{{.Image}}'])
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+
+    if (!lines.length) {
+      return null
+    }
+
+    const expectedPrefix = `${composeProjectName(config)}-postgres-`
+    const preferred = lines.find((line) => {
+      const [name, image] = line.split('\t')
+      return name.startsWith(expectedPrefix) && image.startsWith('postgres')
+    })
+    if (preferred) {
+      return preferred.split('\t')[0]
+    }
+
+    const fallback = lines.find((line) => {
+      const [name, image] = line.split('\t')
+      return name.endsWith('-postgres-1') && image.startsWith('postgres')
+    })
+    return fallback ? fallback.split('\t')[0] : null
+  } catch (_error) {
+    return null
+  }
+}
+
+function toBase64(value) {
+  return Buffer.from(String(value), 'utf8').toString('base64')
+}
+
+function runPsqlUpdate(config, sql) {
+  const containerName = detectPostgresContainer(config)
+  if (!containerName) {
+    return {
+      ok: false,
+      reason: 'Local postgres container was not detected'
+    }
+  }
+
+  try {
+    const output = runDocker([
+      'exec',
+      containerName,
+      'psql',
+      '-U',
+      config.postgresUser,
+      '-d',
+      config.postgresDb,
+      '-t',
+      '-A',
+      '-v',
+      'ON_ERROR_STOP=1',
+      '-c',
+      sql
+    ])
+    const match = output.match(/UPDATE\s+(\d+)/)
+    const updatedRows = match ? Number.parseInt(match[1], 10) : 0
+    return {
+      ok: true,
+      updatedRows,
+      containerName
+    }
+  } catch (error) {
+    const stderr = error.stderr ? String(error.stderr).trim() : error.message
+    return {
+      ok: false,
+      reason: stderr || 'psql update failed'
+    }
+  }
+}
+
+function overrideOtpChallenge(config, challengeToken, otpCode, maxAttempts = 5) {
+  const otpHash = bcrypt.hashSync(otpCode, 10)
+  const metadata = `otpHash=${otpHash};attempts=0;maxAttempts=${maxAttempts}`
+  const tokenB64 = toBase64(challengeToken)
+  const metadataB64 = toBase64(metadata)
+
+  const sql =
+    `UPDATE auth_token ` +
+    `SET metadata = convert_from(decode('${metadataB64}','base64'),'UTF8') ` +
+    `WHERE token_value = convert_from(decode('${tokenB64}','base64'),'UTF8') ` +
+    `AND token_type = 'LOGIN_OTP' AND consumed_at IS NULL AND deleted = false;`
+
+  const result = runPsqlUpdate(config, sql)
+  if (!result.ok) {
+    return {
+      ...result,
+      reason: `Unable to override OTP challenge metadata: ${result.reason}`
+    }
+  }
+
+  if (result.updatedRows < 1) {
+    return {
+      ok: false,
+      reason: 'OTP challenge token was not found in auth_token table'
+    }
+  }
+
+  return {
+    ok: true,
+    updatedRows: result.updatedRows,
+    containerName: result.containerName
+  }
+}
+
+function clearUserLockout(config, email) {
+  const emailB64 = toBase64(String(email).toLowerCase())
+  const sql =
+    `UPDATE users ` +
+    `SET failed_login_attempts = 0, locked_until = NULL ` +
+    `WHERE lower(email) = convert_from(decode('${emailB64}','base64'),'UTF8') ` +
+    `AND deleted = false;`
+
+  const result = runPsqlUpdate(config, sql)
+  if (!result.ok) {
+    return {
+      ...result,
+      reason: `Unable to clear lockout for ${email}: ${result.reason}`
+    }
+  }
+
+  if (result.updatedRows < 1) {
+    return {
+      ok: false,
+      reason: `No user row found for ${email}`
+    }
+  }
+
+  return {
+    ok: true,
+    updatedRows: result.updatedRows,
+    containerName: result.containerName
+  }
+}
+
+module.exports = {
+  overrideOtpChallenge,
+  clearUserLockout
+}

--- a/tests/auth/otp-lockout.e2e.test.js
+++ b/tests/auth/otp-lockout.e2e.test.js
@@ -1,0 +1,233 @@
+const { randomSuffix, createStrongPassword } = require('../../src/utils/dataFactory')
+const { AbstractApiTest } = require('../../src/core/abstractApiTest')
+const { createUnit, loginWithEmail, onboardSocietyWithAdmin } = require('../../src/utils/onboarding')
+const { clearUserLockout, overrideOtpChallenge } = require('../../src/utils/localDbTestHelpers')
+
+function ensureExpectedStatus(response, expectedStatuses, method, path) {
+  if (expectedStatuses.includes(response.status)) {
+    return
+  }
+
+  throw new Error(
+    `${method} ${path} expected ${expectedStatuses.join(' or ')}, got ${response.status} (${response.body?.message || 'no message'})`
+  )
+}
+
+describe('Auth OTP and lockout hardening flows', () => {
+  const suite = new AbstractApiTest()
+  const context = {
+    setupBlockedReason: null
+  }
+
+  function skipIfSetupBlocked() {
+    if (!context.setupBlockedReason) {
+      return false
+    }
+
+    expect(context.setupBlockedReason).toMatch(/SHIELD_(ADMIN_EMAIL|ADMIN_PASSWORD|ROOT_PASSWORD)/)
+    return true
+  }
+
+  async function createUser(role, unitId, accessToken, namePrefix) {
+    const suffix = randomSuffix().replace(/[^0-9]/g, '')
+    const password = createStrongPassword(role)
+    const response = await suite.api.post(
+      '/api/v1/users',
+      {
+        unitId,
+        name: `${namePrefix} ${suffix}`,
+        email: `${role.toLowerCase()}.${namePrefix.toLowerCase()}.${suffix}@shieldguard.test`,
+        phone: `+9177${suffix.slice(-8)}`,
+        password,
+        role
+      },
+      accessToken
+    )
+    ensureExpectedStatus(response, [200], 'POST', '/api/v1/users')
+
+    return {
+      user: response.body.data,
+      credentials: {
+        email: response.body.data.email,
+        password
+      }
+    }
+  }
+
+  async function sendOtpChallenge(email) {
+    const response = await suite.api.post('/api/v1/auth/login/otp/send', { email })
+    ensureExpectedStatus(response, [200], 'POST', '/api/v1/auth/login/otp/send')
+    expect(response.body.data.challengeToken).toBeTruthy()
+    return response.body.data
+  }
+
+  beforeAll(async () => {
+    await suite.setup()
+
+    try {
+      if (suite.config.adminEmail && suite.config.adminPassword) {
+        context.adminSession = await loginWithEmail(suite.api, suite.config.adminEmail, suite.config.adminPassword)
+      } else {
+        const onboarding = await onboardSocietyWithAdmin(suite.api, suite.config)
+        if (onboarding.onboardingBlocked) {
+          context.setupBlockedReason =
+            `${onboarding.onboardingBlockedReason || 'Tenant admin onboarding unavailable.'} ` +
+            'Set SHIELD_ADMIN_EMAIL and SHIELD_ADMIN_PASSWORD in ShieldGuard/.env for SG-0001 execution in strict environments.'
+          return
+        }
+        context.adminSession = onboarding.adminSession
+      }
+    } catch (error) {
+      const message = error?.message || 'Auth setup failed'
+      context.setupBlockedReason =
+        `${message}. Set SHIELD_ROOT_PASSWORD or provide SHIELD_ADMIN_EMAIL and SHIELD_ADMIN_PASSWORD in ShieldGuard/.env.`
+      return
+    }
+
+    if (!context.adminSession?.accessToken) {
+      context.setupBlockedReason =
+        'Tenant admin session unavailable. Set SHIELD_ADMIN_EMAIL and SHIELD_ADMIN_PASSWORD in ShieldGuard/.env.'
+      return
+    }
+
+    context.unit = await createUnit(suite.api, context.adminSession.accessToken, {
+      block: 'AUTH',
+      unitNumber: `AU-${randomSuffix().slice(-4)}`
+    })
+
+    const otpActor = await createUser('OWNER', context.unit.id, context.adminSession.accessToken, 'OtpUser')
+    context.otpUser = {
+      ...otpActor,
+      phone: otpActor.user.phone
+    }
+
+    const lockoutActor = await createUser('TENANT', context.unit.id, context.adminSession.accessToken, 'LockoutUser')
+    context.lockoutUser = {
+      ...lockoutActor
+    }
+  })
+
+  afterAll(async () => {
+    await suite.teardown()
+  })
+
+  it('sends OTP login challenge with stable response shape', async () => {
+    if (skipIfSetupBlocked()) {
+      return
+    }
+
+    const otpChallenge = await sendOtpChallenge(context.otpUser.credentials.email)
+    expect(typeof otpChallenge.challengeToken).toBe('string')
+    expect(otpChallenge.challengeToken.length).toBeGreaterThan(20)
+    expect(otpChallenge.destination).toBeTruthy()
+    expect(otpChallenge.destination).toContain(context.otpUser.phone.slice(-4))
+    expect(otpChallenge.expiresAt).toBeTruthy()
+  })
+
+  it('verifies OTP success path and rejects challenge replay', async () => {
+    if (skipIfSetupBlocked()) {
+      return
+    }
+
+    const otpChallenge = await sendOtpChallenge(context.otpUser.credentials.email)
+    let otpCode = suite.config.otpTestCode
+    let otpSource = 'env'
+
+    if (!otpCode) {
+      otpCode = '654321'
+      const overrideResult = overrideOtpChallenge(
+        suite.config,
+        otpChallenge.challengeToken,
+        otpCode,
+        suite.config.loginOtpMaxAttempts
+      )
+
+      if (!overrideResult.ok) {
+        expect(overrideResult.reason.toLowerCase()).toContain('otp')
+        expect(
+          `Unable to auto-seed OTP challenge. Set SHIELD_OTP_TEST_CODE in ShieldGuard/.env. ${overrideResult.reason}`
+        ).toContain('SHIELD_OTP_TEST_CODE')
+        return
+      }
+      otpSource = 'local-db-override'
+    }
+
+    const verifyResponse = await suite.api.post('/api/v1/auth/login/otp/verify', {
+      challengeToken: otpChallenge.challengeToken,
+      otpCode
+    })
+    ensureExpectedStatus(verifyResponse, [200], 'POST', '/api/v1/auth/login/otp/verify')
+    expect(verifyResponse.body.data.accessToken).toBeTruthy()
+    expect(verifyResponse.body.data.refreshToken).toBeTruthy()
+    expect(otpSource).toBeTruthy()
+
+    const replayResponse = await suite.api.post('/api/v1/auth/login/otp/verify', {
+      challengeToken: otpChallenge.challengeToken,
+      otpCode
+    })
+    ensureExpectedStatus(replayResponse, [400], 'POST', '/api/v1/auth/login/otp/verify')
+  })
+
+  it('enforces invalid OTP attempt limits and challenge invalidation', async () => {
+    if (skipIfSetupBlocked()) {
+      return
+    }
+
+    const maxAttempts = Math.max(1, suite.config.loginOtpMaxAttempts)
+    const otpChallenge = await sendOtpChallenge(context.otpUser.credentials.email)
+
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const invalidResponse = await suite.api.post('/api/v1/auth/login/otp/verify', {
+        challengeToken: otpChallenge.challengeToken,
+        otpCode: '111111'
+      })
+      ensureExpectedStatus(invalidResponse, [401], 'POST', '/api/v1/auth/login/otp/verify')
+    }
+
+    const consumedResponse = await suite.api.post('/api/v1/auth/login/otp/verify', {
+      challengeToken: otpChallenge.challengeToken,
+      otpCode: '111111'
+    })
+    ensureExpectedStatus(consumedResponse, [400], 'POST', '/api/v1/auth/login/otp/verify')
+  })
+
+  it('locks account after failed password attempts and validates recovery path', async () => {
+    if (skipIfSetupBlocked()) {
+      return
+    }
+
+    clearUserLockout(suite.config, context.lockoutUser.credentials.email)
+    const maxFailedAttempts = Math.max(1, suite.config.userLockoutMaxFailedAttempts)
+
+    for (let attempt = 0; attempt < maxFailedAttempts; attempt += 1) {
+      const invalidLoginResponse = await suite.api.post('/api/v1/auth/login', {
+        email: context.lockoutUser.credentials.email,
+        password: 'WrongPassword!999'
+      })
+      ensureExpectedStatus(invalidLoginResponse, [401], 'POST', '/api/v1/auth/login')
+    }
+
+    const lockedLoginResponse = await suite.api.post('/api/v1/auth/login', {
+      email: context.lockoutUser.credentials.email,
+      password: context.lockoutUser.credentials.password
+    })
+    ensureExpectedStatus(lockedLoginResponse, [401], 'POST', '/api/v1/auth/login')
+    expect((lockedLoginResponse.body?.message || '').toLowerCase()).toContain('locked')
+
+    const clearResult = clearUserLockout(suite.config, context.lockoutUser.credentials.email)
+    if (!clearResult.ok) {
+      expect(
+        `Unable to clear lockout state automatically. ${clearResult.reason}. ` +
+          'Provide local DB access or set short lockout duration for auth E2E runs.'
+      ).toContain('lockout')
+      return
+    }
+
+    const recoveredLoginResponse = await suite.api.post('/api/v1/auth/login', {
+      email: context.lockoutUser.credentials.email,
+      password: context.lockoutUser.credentials.password
+    })
+    ensureExpectedStatus(recoveredLoginResponse, [200], 'POST', '/api/v1/auth/login')
+    expect(recoveredLoginResponse.body.data.accessToken).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary\n- add  covering OTP send/verify, invalid attempts, replay, and lockout recovery\n- add local Postgres helper for deterministic OTP and lockout state control when test OTP is not externally exposed\n- extend env config, sample env, README, and npm scripts for running auth-focused suites\n\n## Validation\n- 
> shieldguard@1.0.0 test:e2e:auth-otp-lockout
> jest --runInBand --config jest.config.cjs tests/auth/otp-lockout.e2e.test.js\n\nCloses #2