### PR TITLE
SG-0008: Strengthen observability guardrails and diagnostics delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ ShieldGuard/
 │   ├── inspect-containers.cjs
 │   ├── run-e2e-with-diagnostics.cjs
 │   └── shield-runtime.cjs
+├── docs/
+│   ├── DIAGNOSTICS_GUIDE.md
+│   ├── KANBAN_TICKETS_SG.md
+│   └── TEAM_ONBOARDING.md
 ├── src/
 │   ├── clients/
 │   │   └── shieldApiClient.js
@@ -161,10 +165,12 @@ npm run test:e2e:amenities-meeting
 If SHIELD becomes unstable during test runs:
 1. Run `npm run shield:inspect` to capture container status and logs.
 2. Check generated reports under `ShieldGuard/reports/`.
-3. Look for restart loops, database auth errors, or startup exceptions.
-4. Re-run `npm run test:e2e` after fixing env/runtime mismatch.
+3. Start from the latest `shield-diagnostics-delta-e2e-*.log` report to inspect restart deltas and status transitions.
+4. If run failed, inspect `shield-diagnostics-failure-e2e-*.log` for failure-context logs.
+5. Re-run `npm run test:e2e` after fixing env/runtime mismatch.
 
-`test:e2e` captures diagnostics automatically before and after the suite.
+`test:e2e` captures diagnostics automatically before/after the suite, plus delta reports and failure-context artifacts.
+Detailed interpretation is documented in `docs/DIAGNOSTICS_GUIDE.md`.
 
 ## Test Catalog
 

--- a/docs/DIAGNOSTICS_GUIDE.md
+++ b/docs/DIAGNOSTICS_GUIDE.md
@@ -1,0 +1,47 @@
+# ShieldGuard Diagnostics Interpretation Guide
+
+This guide explains the runtime artifacts produced by `npm run test:e2e` when ShieldGuard runs with diagnostics enabled.
+
+## Report Files
+
+ShieldGuard writes reports in `ShieldGuard/reports/` with timestamped names:
+
+- `shield-diagnostics-before-e2e-*.log`
+  - Container state before Jest executes.
+- `shield-diagnostics-after-e2e-*.log`
+  - Container state immediately after Jest completes.
+- `shield-diagnostics-delta-e2e-*.log`
+  - Before/after comparison containing restart deltas, status changes, and synthesized hints.
+- `shield-diagnostics-failure-e2e-*.log`
+  - Failure-context snapshot with logs (generated when tests fail or runtime instability is detected).
+- `shield-diagnostics-failure-delta-e2e-*.log`
+  - Comparison between initial snapshot and failure-context snapshot.
+
+## How to Triage a Failed Run
+
+1. Open the latest `shield-diagnostics-delta-e2e-*.log` first.
+2. Check `restartDeltas`:
+   - Any `+N` value means a container restarted during the run.
+3. Check `statusChanges`:
+   - Look for transitions like `Up -> Restarting` or `Up -> Exited`.
+4. Check `hints` for known failure signatures:
+   - Database auth mismatch
+   - DB connection acquisition failures
+   - OOM conditions
+   - Port conflicts
+5. If present, inspect `shield-diagnostics-failure-e2e-*.log` for raw container logs.
+
+## Typical Root Causes and Actions
+
+- `password authentication failed for user`
+  - Verify SHIELD env values (`SHIELD_ENV_FILE`, DB credentials) and persisted DB volume state.
+- `unable to obtain connection from database`
+  - Verify database container health and startup ordering.
+- `OutOfMemoryError`
+  - Increase container memory limits or reduce parallel load.
+- `address already in use`
+  - Resolve local port conflicts before rerun.
+
+## Operational Rule
+
+Treat any non-zero `restartDeltas` or unstable container status as runtime instability, even when all test assertions pass.

--- a/scripts/run-e2e-with-diagnostics.cjs
+++ b/scripts/run-e2e-with-diagnostics.cjs
@@ -3,7 +3,10 @@ const { spawnSync } = require('child_process');
 const { loadConfig } = require('../src/config/env');
 const {
   collectDiagnostics,
+  compareDiagnostics,
   summarizeDiagnostics,
+  summarizeComparison,
+  writeComparisonReport,
   writeDiagnosticsReport
 } = require('../src/utils/containerDiagnostics');
 
@@ -28,29 +31,32 @@ function printSnapshot(config, label, includeLogs) {
   return diagnostics;
 }
 
-function isMoreUnstable(before, after) {
-  if (!before || !after) {
-    return false;
-  }
-
-  const beforeMap = new Map(before.containers.map((container) => [container.name, container.restartCount]));
-  return after.containers.some((container) => {
-    const previous = beforeMap.get(container.name) ?? 0;
-    return container.restartCount > previous;
-  });
-}
-
 const config = loadConfig();
 const before = printSnapshot(config, 'before-e2e', false);
 const jestResult = runJest();
 const after = printSnapshot(config, 'after-e2e', jestResult.status !== 0);
+const comparison = compareDiagnostics(before, after);
+const comparisonReportPath = writeComparisonReport(config, comparison, 'delta-e2e');
 
-const restartIncreased = isMoreUnstable(before, after);
-const becameUnstable = after.unstable;
+console.log('[ShieldGuard] before/after diagnostics delta');
+console.log(summarizeComparison(comparison));
+console.log(`Delta report: ${comparisonReportPath}\n`);
 
-if (restartIncreased || becameUnstable) {
+const testFailed = (jestResult.status ?? 1) !== 0;
+const runtimeUnstable =
+  comparison.becameUnstable || comparison.restartDeltas.length > 0 || after.unstable;
+
+if (testFailed || runtimeUnstable) {
+  const failureSnapshot = printSnapshot(config, 'failure-e2e', true);
+  const failureComparison = compareDiagnostics(before, failureSnapshot);
+  const failureComparisonPath = writeComparisonReport(config, failureComparison, 'failure-delta-e2e');
+  console.error('[ShieldGuard] Failure-context diagnostics captured.');
+  console.error(`Failure delta report: ${failureComparisonPath}`);
+}
+
+if (runtimeUnstable) {
   console.error('[ShieldGuard] Container instability detected during/after test execution.');
-  console.error('Review diagnostics reports under ShieldGuard/reports/.');
+  console.error('Review diagnostics reports under ShieldGuard/reports/ and start from delta-e2e report.');
   process.exit(1);
 }
 

--- a/src/utils/containerDiagnostics.js
+++ b/src/utils/containerDiagnostics.js
@@ -200,8 +200,162 @@ function summarizeDiagnostics(diagnostics) {
   return lines.join('\n');
 }
 
+function compareDiagnostics(before, after) {
+  const beforeMap = new Map((before?.containers || []).map((container) => [container.name, container]))
+  const afterMap = new Map((after?.containers || []).map((container) => [container.name, container]))
+
+  const allNames = [...new Set([...beforeMap.keys(), ...afterMap.keys()])].sort()
+  const restartDeltas = []
+  const statusChanges = []
+  const missingAfter = []
+  const newContainers = []
+
+  allNames.forEach((name) => {
+    const previous = beforeMap.get(name)
+    const current = afterMap.get(name)
+
+    if (!current) {
+      missingAfter.push(name)
+      return
+    }
+
+    if (!previous) {
+      newContainers.push(name)
+    } else if (previous.status !== current.status) {
+      statusChanges.push({
+        name,
+        beforeStatus: previous.status,
+        afterStatus: current.status
+      })
+    }
+
+    const beforeRestart = previous?.restartCount || 0
+    const afterRestart = current.restartCount || 0
+    if (afterRestart > beforeRestart) {
+      restartDeltas.push({
+        name,
+        beforeRestart,
+        afterRestart,
+        delta: afterRestart - beforeRestart
+      })
+    }
+  })
+
+  const hints = []
+  if (restartDeltas.length) {
+    restartDeltas.forEach((entry) => {
+      hints.push(`${entry.name} restart count increased by ${entry.delta} (${entry.beforeRestart} -> ${entry.afterRestart}).`)
+    })
+  }
+  if (missingAfter.length) {
+    hints.push(`Containers missing after run: ${missingAfter.join(', ')}.`)
+  }
+  if (newContainers.length) {
+    hints.push(`New containers detected after run: ${newContainers.join(', ')}.`)
+  }
+  if (after?.hints?.length) {
+    hints.push(...after.hints)
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    project: after?.project || before?.project || 'unknown',
+    restartDeltas,
+    statusChanges,
+    missingAfter,
+    newContainers,
+    unstableBefore: Boolean(before?.unstable),
+    unstableAfter: Boolean(after?.unstable),
+    becameUnstable: !before?.unstable && Boolean(after?.unstable),
+    hints: [...new Set(hints)]
+  }
+}
+
+function summarizeComparison(comparison) {
+  const lines = []
+  lines.push(`Project: ${comparison.project}`)
+  lines.push(`Became unstable: ${comparison.becameUnstable}`)
+  lines.push(`Restart deltas: ${comparison.restartDeltas.length}`)
+  lines.push(`Status changes: ${comparison.statusChanges.length}`)
+  lines.push(`Missing after run: ${comparison.missingAfter.length}`)
+  lines.push(`New containers: ${comparison.newContainers.length}`)
+
+  if (comparison.restartDeltas.length) {
+    lines.push('Restart delta details:')
+    comparison.restartDeltas.forEach((entry) => {
+      lines.push(`  - ${entry.name}: +${entry.delta} (${entry.beforeRestart} -> ${entry.afterRestart})`)
+    })
+  }
+
+  if (comparison.statusChanges.length) {
+    lines.push('Status changes:')
+    comparison.statusChanges.forEach((entry) => {
+      lines.push(`  - ${entry.name}: ${entry.beforeStatus} -> ${entry.afterStatus}`)
+    })
+  }
+
+  if (comparison.hints.length) {
+    lines.push('Hints:')
+    comparison.hints.forEach((hint) => lines.push(`  - ${hint}`))
+  }
+
+  return lines.join('\n')
+}
+
+function writeComparisonReport(config, comparison, label = 'comparison') {
+  const dirPath = ensureReportsDir(config)
+  const safeLabel = String(label || 'comparison').replace(/[^a-zA-Z0-9_-]/g, '_')
+  const fileName = `shield-diagnostics-${safeLabel}-${Date.now()}.log`
+  const reportPath = path.join(dirPath, fileName)
+
+  const lines = []
+  lines.push(`timestamp=${comparison.timestamp}`)
+  lines.push(`project=${comparison.project}`)
+  lines.push(`unstableBefore=${comparison.unstableBefore}`)
+  lines.push(`unstableAfter=${comparison.unstableAfter}`)
+  lines.push(`becameUnstable=${comparison.becameUnstable}`)
+  lines.push('')
+
+  lines.push('restartDeltas:')
+  if (!comparison.restartDeltas.length) {
+    lines.push('  (none)')
+  } else {
+    comparison.restartDeltas.forEach((entry) => {
+      lines.push(`  - ${entry.name}: +${entry.delta} (${entry.beforeRestart} -> ${entry.afterRestart})`)
+    })
+  }
+
+  lines.push('')
+  lines.push('statusChanges:')
+  if (!comparison.statusChanges.length) {
+    lines.push('  (none)')
+  } else {
+    comparison.statusChanges.forEach((entry) => {
+      lines.push(`  - ${entry.name}: ${entry.beforeStatus} -> ${entry.afterStatus}`)
+    })
+  }
+
+  lines.push('')
+  lines.push('missingAfter:')
+  lines.push(comparison.missingAfter.length ? `  - ${comparison.missingAfter.join('\n  - ')}` : '  (none)')
+
+  lines.push('')
+  lines.push('newContainers:')
+  lines.push(comparison.newContainers.length ? `  - ${comparison.newContainers.join('\n  - ')}` : '  (none)')
+
+  lines.push('')
+  lines.push('hints:')
+  lines.push(comparison.hints.length ? `  - ${comparison.hints.join('\n  - ')}` : '  (none)')
+
+  fs.writeFileSync(reportPath, `${lines.join('\n')}\n`, 'utf8')
+  return reportPath
+}
+
 module.exports = {
   collectDiagnostics,
+  compareDiagnostics,
+  writeComparisonReport,
   writeDiagnosticsReport,
+  summarizeComparison,
   summarizeDiagnostics
 };


### PR DESCRIPTION
## Summary
- add before/after diagnostics comparison utilities with restart deltas and status transition tracking
- generate `delta-e2e` and `failure-delta-e2e` reports during `test:e2e` runs
- capture failure-context snapshots automatically when tests fail or runtime instability is detected
- document diagnostics interpretation workflow in `docs/DIAGNOSTICS_GUIDE.md`
- update README crash-triage section to align with new artifacts

## Validation
- npm run test:e2e:amenities-meeting
- node -e "const d=require('./src/utils/containerDiagnostics'); const c=d.compareDiagnostics({containers:[{name:'a',status:'Up',restartCount:0}],unstable:false,project:'p'},{containers:[{name:'a',status:'Restarting',restartCount:2}],unstable:true,project:'p',hints:['x']}); console.log(d.summarizeComparison(c));"

Closes #9
