### PR TITLE
SG-0009: Add CI workflow with diagnostics artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: ShieldGuard CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shieldguard-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: E2E with Diagnostics
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout ShieldGuard
+        uses: actions/checkout@v4
+
+      - name: Checkout SHIELD backend
+        uses: actions/checkout@v4
+        with:
+          repository: VrushankPatel/shield
+          path: shield
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Install ShieldGuard dependencies
+        run: npm ci
+
+      - name: Build SHIELD backend jar
+        working-directory: ./shield
+        run: mvn -B -DskipTests package
+
+      - name: Execute ShieldGuard E2E suite
+        env:
+          SHIELD_BASE_URL: http://localhost:8080
+          SHIELD_AUTOSTART: 'true'
+          SHIELD_AUTOSTOP: 'true'
+          SHIELD_PROJECT_DIR: ./shield
+          SHIELD_RUN_SCRIPT: ./shield/run.sh
+          SHIELD_ENV_FILE: ./shield/dev.env
+          SHIELD_ROOT_CREDENTIAL_FILE: ./shield/root-bootstrap-credential.txt
+          SHIELD_INSTANCES: '2'
+          SHIELD_PROXY: haproxy
+        run: npm run test:e2e
+
+      - name: Capture failure diagnostics snapshot
+        if: failure()
+        env:
+          SHIELD_PROJECT_DIR: ./shield
+          SHIELD_RUN_SCRIPT: ./shield/run.sh
+          SHIELD_ENV_FILE: ./shield/dev.env
+          SHIELD_INSTANCES: '2'
+          SHIELD_PROXY: haproxy
+        run: node scripts/inspect-containers.cjs --logs --label ci-failure
+
+      - name: Stop SHIELD runtime
+        if: always()
+        env:
+          SHIELD_PROJECT_DIR: ./shield
+          SHIELD_RUN_SCRIPT: ./shield/run.sh
+          SHIELD_ENV_FILE: ./shield/dev.env
+          SHIELD_INSTANCES: '2'
+          SHIELD_PROXY: haproxy
+        run: npm run shield:stop
+        continue-on-error: true
+
+      - name: Upload diagnostics artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shieldguard-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            reports/**
+            shield/system_topologies/generated/**

--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ Run only amenities and meeting lifecycle checks:
 npm run test:e2e:amenities-meeting
 ```
 
+## CI Pipeline
+
+GitHub Actions workflow: `.github/workflows/ci.yml`
+
+- Triggers on pull requests to `master` and pushes to `master`.
+- Checks out both repositories:
+  - `ShieldGuard` (this repo)
+  - `shield` backend (for runtime + API under test)
+- Builds SHIELD backend jar with Maven.
+- Runs `npm run test:e2e` with ShieldGuard diagnostics enabled.
+- Always uploads diagnostics artifacts (`reports/` and generated topology configs), including failure-context snapshots when runs fail.
+
 ## Crash Triage Workflow
 
 If SHIELD becomes unstable during test runs:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow at `.github/workflows/ci.yml`
- trigger CI on PR to `master` and pushes to `master`
- checkout SHIELD backend, build jar, and execute `npm run test:e2e`
- capture failure diagnostics and always upload reports as downloadable artifacts
- document CI behavior in README

## Validation
- npm run test:e2e:auth-otp-lockout

Closes #10
