### PR TITLE
SG-0013: add full role matrix and edge permutation E2E coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This suite currently targets:
 - utility monitoring and marketplace transaction flows
 - communication module lifecycle flows
 - config, document repository, and analytics governance flows
+- full role-permission matrix verification across business domains
+- exhaustive negative and edge permutation coverage across business domains
 - admin refresh token rotation (`/auth/refresh` and `/auth/refresh-token`)
 - session invalidation on logout
 - session invalidation on password change
@@ -61,6 +63,8 @@ ShieldGuard/
 └── tests/
     ├── accounting/
     │   └── accounting-treasury-flows.e2e.test.js
+    ├── authorization/
+    │   └── role-permission-matrix.e2e.test.js
     ├── amenities-meeting/
     │   └── amenities-meeting-flows.e2e.test.js
     ├── asset-complaint/
@@ -80,6 +84,8 @@ ShieldGuard/
     │   └── communication-flows.e2e.test.js
     ├── config-document-analytics/
     │   └── config-document-analytics-flows.e2e.test.js
+    ├── edge-permutations/
+    │   └── domain-edge-permutations.e2e.test.js
     ├── staff-payroll/
     │   └── staff-payroll-flows.e2e.test.js
     ├── utility-marketplace/
@@ -211,6 +217,18 @@ Run only config, document, and analytics lifecycle checks:
 
 ```bash
 npm run test:e2e:config-document-analytics
+```
+
+Run the full role-permission matrix suite:
+
+```bash
+npm run test:e2e:role-matrix
+```
+
+Run cross-domain negative and edge permutations:
+
+```bash
+npm run test:e2e:edge-permutations
 ```
 
 ## CI Pipeline
@@ -383,6 +401,26 @@ Detailed interpretation is documented in `docs/DIAGNOSTICS_GUIDE.md`.
   - Covers tenant config upsert/bulk update, module toggles, billing formula config, and document category/document lifecycle.
 - `drives report templates, scheduled reports, dashboards, and analytics endpoints`
   - Covers report template execution, scheduled report send-now, dashboard defaulting, and core analytics endpoint verification with seeded operational data.
+
+### `role-permission-matrix.e2e.test.js`
+
+- `enforces expected permissions for each role and unauthenticated callers`
+  - Verifies access behavior for `ADMIN`, `COMMITTEE`, `SECURITY`, `OWNER`, `TENANT`, and unauthenticated requests.
+  - Covers matrix checks across:
+    - accounting/treasury
+    - staff/payroll
+    - utility monitoring
+    - marketplace
+    - documents/files
+    - notifications
+    - config/settings
+    - analytics/reports
+
+### `domain-edge-permutations.e2e.test.js`
+
+- `covers validation failures, forbidden paths, and missing-resource permutations`
+  - Executes cross-domain negative and edge permutations for all core business domains.
+  - Includes malformed payloads, invalid UUIDs, forbidden-role actions, not-found resources, and unauthenticated access checks.
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:e2e:utility-marketplace": "jest --runInBand --config jest.config.cjs tests/utility-marketplace/utility-marketplace-flows.e2e.test.js",
     "test:e2e:communication": "jest --runInBand --config jest.config.cjs tests/communication/communication-flows.e2e.test.js",
     "test:e2e:config-document-analytics": "jest --runInBand --config jest.config.cjs tests/config-document-analytics/config-document-analytics-flows.e2e.test.js",
+    "test:e2e:role-matrix": "jest --runInBand --config jest.config.cjs tests/authorization/role-permission-matrix.e2e.test.js",
+    "test:e2e:edge-permutations": "jest --runInBand --config jest.config.cjs tests/edge-permutations/domain-edge-permutations.e2e.test.js",
     "test:e2e:watch": "jest --watch --config jest.config.cjs",
     "shield:start": "node scripts/shield-runtime.cjs start",
     "shield:stop": "node scripts/shield-runtime.cjs stop",

--- a/src/utils/flowHarness.js
+++ b/src/utils/flowHarness.js
@@ -69,9 +69,23 @@ async function createUser(suite, accessToken, unitId, role, namePrefix) {
   }
 }
 
+async function createRoleSessions(suite, accessToken, unitId, roles = ['COMMITTEE', 'SECURITY', 'OWNER', 'TENANT']) {
+  const sessions = {}
+  const users = {}
+
+  for (const role of roles) {
+    const created = await createUser(suite, accessToken, unitId, role, `${role}RoleUser`)
+    users[role] = created.user
+    sessions[role] = await loginWithEmail(suite.api, created.credentials.email, created.credentials.password)
+  }
+
+  return { sessions, users }
+}
+
 module.exports = {
   ensureExpectedStatus,
   resolveAdminSession,
   skipIfSetupBlocked,
-  createUser
+  createUser,
+  createRoleSessions
 }

--- a/tests/authorization/role-permission-matrix.e2e.test.js
+++ b/tests/authorization/role-permission-matrix.e2e.test.js
@@ -1,0 +1,328 @@
+const { randomSuffix } = require('../../src/utils/dataFactory')
+const { AbstractApiTest } = require('../../src/core/abstractApiTest')
+const { createUnit } = require('../../src/utils/onboarding')
+const {
+  ensureExpectedStatus,
+  resolveAdminSession,
+  skipIfSetupBlocked,
+  createRoleSessions
+} = require('../../src/utils/flowHarness')
+
+const ROLES = ['ADMIN', 'COMMITTEE', 'SECURITY', 'OWNER', 'TENANT']
+
+function callEndpoint(api, method, path, body, accessToken) {
+  if (method === 'GET') {
+    return api.get(path, accessToken)
+  }
+  if (method === 'POST') {
+    return api.post(path, body || {}, accessToken)
+  }
+  if (method === 'PUT') {
+    return api.put(path, body || {}, accessToken)
+  }
+  throw new Error(`Unsupported method ${method}`)
+}
+
+describe('Role-permission matrix across core business domains', () => {
+  const suite = new AbstractApiTest()
+  const context = {
+    setupBlockedReason: null,
+    sessions: {},
+    users: {},
+    seeds: {}
+  }
+
+  beforeAll(async () => {
+    await suite.setup()
+    await resolveAdminSession(suite, context, 'SG-0013 role matrix')
+    if (context.setupBlockedReason) {
+      return
+    }
+
+    context.sessions.ADMIN = context.adminSession
+
+    context.unit = await createUnit(suite.api, context.adminSession.accessToken, {
+      block: 'RLM',
+      unitNumber: `RM-${randomSuffix().slice(-4)}`
+    })
+
+    const roleBootstrap = await createRoleSessions(suite, context.adminSession.accessToken, context.unit.id)
+    for (const [role, session] of Object.entries(roleBootstrap.sessions)) {
+      context.sessions[role] = session
+    }
+    for (const [role, user] of Object.entries(roleBootstrap.users)) {
+      context.users[role] = user
+    }
+
+    const suffix = randomSuffix().replace(/[^0-9]/g, '')
+    const currentYear = new Date().getUTCFullYear()
+
+    const seedStaffResponse = await suite.api.post(
+      '/api/v1/staff',
+      {
+        employeeId: `RM-ST-${suffix.slice(-4)}`,
+        firstName: 'Matrix',
+        lastName: 'Staff',
+        phone: '+919999111122',
+        email: `matrix.staff.${suffix}@shieldguard.test`,
+        designation: 'MANAGER',
+        dateOfJoining: `${currentYear}-01-01`,
+        employmentType: 'FULL_TIME',
+        basicSalary: 25000,
+        active: true
+      },
+      context.adminSession.accessToken
+    )
+    ensureExpectedStatus(seedStaffResponse, [200], 'POST', '/api/v1/staff')
+    context.seeds.staffId = seedStaffResponse.body.data.id
+
+    const seedDocumentCategoryResponse = await suite.api.post(
+      '/api/v1/document-categories',
+      {
+        categoryName: `Role Matrix Docs ${suffix}`,
+        description: 'Role matrix seeded document category',
+        parentCategoryId: null
+      },
+      context.adminSession.accessToken
+    )
+    ensureExpectedStatus(seedDocumentCategoryResponse, [200], 'POST', '/api/v1/document-categories')
+    context.seeds.documentCategoryId = seedDocumentCategoryResponse.body.data.id
+    context.seeds.suffix = suffix
+  })
+
+  afterAll(async () => {
+    await suite.teardown()
+  })
+
+  it('enforces expected permissions for each role and unauthenticated callers', async () => {
+    if (skipIfSetupBlocked(context)) {
+      return
+    }
+
+    const currentYear = new Date().getUTCFullYear()
+
+    const entries = [
+      {
+        key: 'accountHeadCreate',
+        domain: 'Accounting/Treasury',
+        method: 'POST',
+        path: '/api/v1/account-heads',
+        allowedRoles: ['ADMIN', 'COMMITTEE'],
+        body: (role) => ({
+          headName: `RM Account Head ${context.seeds.suffix}-${role}`,
+          headType: 'EXPENSE'
+        })
+      },
+      {
+        key: 'accountHeadList',
+        domain: 'Accounting/Treasury',
+        method: 'GET',
+        path: '/api/v1/account-heads?page=0&size=5',
+        allowedRoles: ['ADMIN', 'COMMITTEE', 'SECURITY', 'OWNER', 'TENANT']
+      },
+      {
+        key: 'staffCreate',
+        domain: 'Staff/Payroll',
+        method: 'POST',
+        path: '/api/v1/staff',
+        allowedRoles: ['ADMIN', 'COMMITTEE'],
+        body: (role) => ({
+          employeeId: `RM-${role}-${context.seeds.suffix.slice(-4)}`,
+          firstName: 'Role',
+          lastName: `Staff${role}`,
+          phone: `+9188${context.seeds.suffix.slice(-8)}`,
+          email: `rm.staff.${role.toLowerCase()}.${context.seeds.suffix}@shieldguard.test`,
+          designation: 'SECURITY_GUARD',
+          dateOfJoining: `${currentYear}-01-01`,
+          employmentType: 'FULL_TIME',
+          basicSalary: 18000,
+          active: true
+        })
+      },
+      {
+        key: 'payrollGenerate',
+        domain: 'Staff/Payroll',
+        method: 'POST',
+        path: '/api/v1/payroll/generate',
+        allowedRoles: ['ADMIN', 'COMMITTEE'],
+        body: (role) => ({
+          staffId: context.seeds.staffId,
+          month: role === 'ADMIN' ? 6 : 7,
+          year: currentYear,
+          workingDays: 26,
+          totalDeductions: 0
+        })
+      },
+      {
+        key: 'waterTankCreate',
+        domain: 'Utility Monitoring',
+        method: 'POST',
+        path: '/api/v1/water-tanks',
+        allowedRoles: ['ADMIN', 'COMMITTEE'],
+        body: (role) => ({
+          tankName: `RM Tank ${context.seeds.suffix}-${role}`,
+          tankType: 'OVERHEAD',
+          capacity: 50000,
+          location: 'Role Matrix Block'
+        })
+      },
+      {
+        key: 'waterTankList',
+        domain: 'Utility Monitoring',
+        method: 'GET',
+        path: '/api/v1/water-tanks?page=0&size=5',
+        allowedRoles: ['ADMIN', 'COMMITTEE', 'SECURITY', 'OWNER', 'TENANT']
+      },
+      {
+        key: 'marketplaceCategoryCreate',
+        domain: 'Marketplace',
+        method: 'POST',
+        path: '/api/v1/marketplace-categories',
+        allowedRoles: ['ADMIN', 'COMMITTEE'],
+        body: (role) => ({
+          categoryName: `RM Category ${context.seeds.suffix}-${role}`,
+          description: 'Role matrix marketplace category'
+        })
+      },
+      {
+        key: 'marketplaceListingCreate',
+        domain: 'Marketplace',
+        method: 'POST',
+        path: '/api/v1/marketplace-listings',
+        allowedRoles: ['ADMIN', 'COMMITTEE', 'SECURITY', 'OWNER', 'TENANT'],
+        body: (role) => ({
+          categoryId: null,
+          listingType: 'SELL',
+          title: `RM Listing ${context.seeds.suffix}-${role}`,
+          description: 'Role matrix listing',
+          price: 1000,
+          negotiable: true,
+          images: 'https://img.shieldguard.test/rm.jpg',
+          unitId: context.unit.id
+        })
+      },
+      {
+        key: 'documentCategoryCreate',
+        domain: 'Documents/Files',
+        method: 'POST',
+        path: '/api/v1/document-categories',
+        allowedRoles: ['ADMIN', 'COMMITTEE'],
+        body: (role) => ({
+          categoryName: `RM DocCat ${context.seeds.suffix}-${role}`,
+          description: 'Role matrix document category',
+          parentCategoryId: null
+        })
+      },
+      {
+        key: 'documentCreate',
+        domain: 'Documents/Files',
+        method: 'POST',
+        path: '/api/v1/documents',
+        allowedRoles: ['ADMIN', 'COMMITTEE'],
+        body: (role) => ({
+          documentName: `RM-Doc-${context.seeds.suffix}-${role}.pdf`,
+          categoryId: context.seeds.documentCategoryId,
+          documentType: 'PDF',
+          fileUrl: `https://files.shieldguard.test/rm-doc-${context.seeds.suffix}-${role}.pdf`,
+          fileSize: 1024,
+          description: 'Role matrix document',
+          versionLabel: 'v1',
+          publicAccess: false,
+          expiryDate: null,
+          tags: 'role,matrix'
+        })
+      },
+      {
+        key: 'filePresignedUrlGenerate',
+        domain: 'Documents/Files',
+        method: 'POST',
+        path: '/api/v1/files/generate-presigned-url',
+        allowedRoles: ['ADMIN', 'COMMITTEE', 'SECURITY'],
+        body: (role) => ({
+          fileName: `rm-${context.seeds.suffix}-${role}.txt`,
+          contentType: 'text/plain',
+          expiresInMinutes: 10
+        })
+      },
+      {
+        key: 'notificationSend',
+        domain: 'Notifications',
+        method: 'POST',
+        path: '/api/v1/notifications/send',
+        allowedRoles: ['ADMIN', 'COMMITTEE'],
+        body: () => ({
+          recipients: [context.users.OWNER.email],
+          subject: 'Role matrix notification',
+          body: 'Permission matrix probe'
+        })
+      },
+      {
+        key: 'notificationList',
+        domain: 'Notifications',
+        method: 'GET',
+        path: '/api/v1/notifications?page=0&size=5',
+        allowedRoles: ['ADMIN', 'COMMITTEE', 'SECURITY', 'OWNER', 'TENANT']
+      },
+      {
+        key: 'tenantConfigList',
+        domain: 'Config/Settings',
+        method: 'GET',
+        path: '/api/v1/config?page=0&size=5',
+        allowedRoles: ['ADMIN', 'COMMITTEE']
+      },
+      {
+        key: 'settingsModuleToggle',
+        domain: 'Config/Settings',
+        method: 'PUT',
+        path: '/api/v1/settings/modules/marketplace/toggle',
+        allowedRoles: ['ADMIN'],
+        body: () => ({
+          enabled: true
+        })
+      },
+      {
+        key: 'reportTemplateCreate',
+        domain: 'Analytics/Reports',
+        method: 'POST',
+        path: '/api/v1/report-templates',
+        allowedRoles: ['ADMIN', 'COMMITTEE'],
+        body: (role) => ({
+          templateName: `RM Template ${context.seeds.suffix}-${role}`,
+          reportType: 'COLLECTION_EFFICIENCY',
+          description: 'Role matrix template',
+          queryTemplate: '',
+          parametersJson: '{}',
+          systemTemplate: false
+        })
+      },
+      {
+        key: 'analyticsCollectionEfficiency',
+        domain: 'Analytics/Reports',
+        method: 'GET',
+        path: '/api/v1/analytics/collection-efficiency',
+        allowedRoles: ['ADMIN', 'COMMITTEE']
+      }
+    ]
+
+    for (const entry of entries) {
+      for (const role of ROLES) {
+        const token = context.sessions[role]?.accessToken
+        const body = entry.body ? entry.body(role) : undefined
+        const response = await callEndpoint(suite.api, entry.method, entry.path, body, token)
+
+        if (entry.allowedRoles.includes(role)) {
+          ensureExpectedStatus(response, [200], `${entry.method} ${entry.key}`, `${entry.domain} (${role})`)
+          if (response.status === 200) {
+            expect(response.body.success).toBe(true)
+          }
+        } else {
+          ensureExpectedStatus(response, [401, 403], `${entry.method} ${entry.key}`, `${entry.domain} (${role})`)
+        }
+      }
+
+      const unauthBody = entry.body ? entry.body('UNAUTH') : undefined
+      const unauthResponse = await callEndpoint(suite.api, entry.method, entry.path, unauthBody)
+      ensureExpectedStatus(unauthResponse, [401, 403], `${entry.method} ${entry.key}`, `${entry.domain} (UNAUTH)`)
+    }
+  })
+})

--- a/tests/edge-permutations/domain-edge-permutations.e2e.test.js
+++ b/tests/edge-permutations/domain-edge-permutations.e2e.test.js
@@ -1,0 +1,367 @@
+const { randomSuffix } = require('../../src/utils/dataFactory')
+const { AbstractApiTest } = require('../../src/core/abstractApiTest')
+const { createUnit } = require('../../src/utils/onboarding')
+const {
+  ensureExpectedStatus,
+  resolveAdminSession,
+  skipIfSetupBlocked,
+  createRoleSessions
+} = require('../../src/utils/flowHarness')
+
+const UNKNOWN_UUID = '11111111-1111-1111-1111-111111111111'
+
+describe('Cross-domain negative and edge permutations', () => {
+  const suite = new AbstractApiTest()
+  const context = {
+    setupBlockedReason: null
+  }
+
+  beforeAll(async () => {
+    await suite.setup()
+    await resolveAdminSession(suite, context, 'SG-0013 edge permutations')
+    if (context.setupBlockedReason) {
+      return
+    }
+
+    context.unit = await createUnit(suite.api, context.adminSession.accessToken, {
+      block: 'EDG',
+      unitNumber: `EG-${randomSuffix().slice(-4)}`
+    })
+
+    const roleBootstrap = await createRoleSessions(suite, context.adminSession.accessToken, context.unit.id)
+    context.sessions = {
+      ADMIN: context.adminSession,
+      ...roleBootstrap.sessions
+    }
+    context.users = roleBootstrap.users
+
+    const suffix = randomSuffix().replace(/[^0-9]/g, '')
+    const currentYear = new Date().getUTCFullYear()
+
+    const categoryResponse = await suite.api.post(
+      '/api/v1/marketplace-categories',
+      {
+        categoryName: `Edge Category ${suffix}`,
+        description: 'Edge tests category'
+      },
+      context.adminSession.accessToken
+    )
+    ensureExpectedStatus(categoryResponse, [200], 'POST', '/api/v1/marketplace-categories')
+    context.marketplaceCategoryId = categoryResponse.body.data.id
+
+    const ownerListingResponse = await suite.api.post(
+      '/api/v1/marketplace-listings',
+      {
+        categoryId: context.marketplaceCategoryId,
+        listingType: 'SELL',
+        title: `Owner Listing ${suffix}`,
+        description: 'Listing for ownership validation',
+        price: 1200,
+        negotiable: true,
+        images: 'https://img.shieldguard.test/owner-listing.jpg',
+        unitId: context.unit.id
+      },
+      context.sessions.OWNER.accessToken
+    )
+    ensureExpectedStatus(ownerListingResponse, [200], 'POST', '/api/v1/marketplace-listings')
+    context.ownerListingId = ownerListingResponse.body.data.id
+
+    const documentCategoryResponse = await suite.api.post(
+      '/api/v1/document-categories',
+      {
+        categoryName: `Edge Docs ${suffix}`,
+        description: 'Edge test docs category',
+        parentCategoryId: null
+      },
+      context.adminSession.accessToken
+    )
+    ensureExpectedStatus(documentCategoryResponse, [200], 'POST', '/api/v1/document-categories')
+    context.documentCategoryId = documentCategoryResponse.body.data.id
+
+    const seededStaffResponse = await suite.api.post(
+      '/api/v1/staff',
+      {
+        employeeId: `EDG-${suffix.slice(-4)}`,
+        firstName: 'Edge',
+        lastName: 'Staff',
+        phone: '+919933224411',
+        email: `edge.staff.${suffix}@shieldguard.test`,
+        designation: 'SECURITY_GUARD',
+        dateOfJoining: `${currentYear}-01-10`,
+        employmentType: 'FULL_TIME',
+        basicSalary: 17000,
+        active: true
+      },
+      context.adminSession.accessToken
+    )
+    ensureExpectedStatus(seededStaffResponse, [200], 'POST', '/api/v1/staff')
+    context.seededStaffId = seededStaffResponse.body.data.id
+  })
+
+  afterAll(async () => {
+    await suite.teardown()
+  })
+
+  it('covers validation failures, forbidden paths, and missing-resource permutations', async () => {
+    if (skipIfSetupBlocked(context)) {
+      return
+    }
+
+    const currentYear = new Date().getUTCFullYear()
+    const longConfigKey = `key-${'x'.repeat(130)}`
+    const suffix = randomSuffix().replace(/[^0-9]/g, '')
+
+    const cases = [
+      {
+        name: 'Accounting: blank account head name rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/account-heads',
+            { headName: '', headType: 'EXPENSE' },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Accounting: malformed UUID rejected on account head lookup',
+        exec: () => suite.api.get('/api/v1/account-heads/not-a-uuid', context.sessions.ADMIN.accessToken),
+        expected: [400]
+      },
+      {
+        name: 'Staff: negative salary rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/staff',
+            {
+              employeeId: `NEG-${suffix.slice(-4)}`,
+              firstName: 'Neg',
+              lastName: 'Salary',
+              phone: '+919900111222',
+              email: `neg.salary.${suffix}@shieldguard.test`,
+              designation: 'MANAGER',
+              dateOfJoining: `${currentYear}-01-01`,
+              employmentType: 'FULL_TIME',
+              basicSalary: -1,
+              active: true
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Payroll: invalid month rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/payroll/generate',
+            {
+              staffId: context.seededStaffId,
+              month: 13,
+              year: currentYear,
+              workingDays: 26,
+              totalDeductions: 0
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Payroll: unknown staff rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/payroll/generate',
+            {
+              staffId: UNKNOWN_UUID,
+              month: 8,
+              year: currentYear,
+              workingDays: 26,
+              totalDeductions: 0
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [404]
+      },
+      {
+        name: 'Utility: negative tank capacity rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/water-tanks',
+            {
+              tankName: `Bad Tank ${suffix}`,
+              tankType: 'OVERHEAD',
+              capacity: -10,
+              location: 'Edge block'
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Utility: unknown tank water log rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/water-level-logs',
+            {
+              tankId: UNKNOWN_UUID,
+              levelPercentage: 55.5,
+              volume: 1000
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [404]
+      },
+      {
+        name: 'Marketplace: blank title rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/marketplace-listings',
+            {
+              categoryId: context.marketplaceCategoryId,
+              listingType: 'SELL',
+              title: '',
+              description: 'Invalid listing',
+              price: 1000,
+              negotiable: true,
+              images: 'https://img.shieldguard.test/x.jpg',
+              unitId: context.unit.id
+            },
+            context.sessions.OWNER.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Marketplace: non-owner cannot mark listing sold',
+        exec: () =>
+          suite.api.post(
+            `/api/v1/marketplace-listings/${context.ownerListingId}/mark-sold`,
+            {},
+            context.sessions.TENANT.accessToken
+          ),
+        expected: [401, 403]
+      },
+      {
+        name: 'Documents: blank file URL rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/documents',
+            {
+              documentName: `BadDoc-${suffix}.pdf`,
+              categoryId: context.documentCategoryId,
+              documentType: 'PDF',
+              fileUrl: '',
+              fileSize: 512,
+              description: 'Missing URL',
+              versionLabel: 'v1',
+              publicAccess: false,
+              expiryDate: null,
+              tags: 'bad'
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Documents: unknown document returns not found',
+        exec: () => suite.api.get(`/api/v1/documents/${UNKNOWN_UUID}`, context.sessions.ADMIN.accessToken),
+        expected: [404]
+      },
+      {
+        name: 'Files: invalid presigned URL expiry rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/files/generate-presigned-url',
+            {
+              fileName: `bad-expiry-${suffix}.txt`,
+              contentType: 'text/plain',
+              expiresInMinutes: 0
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Notifications: invalid email recipient rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/notifications/send',
+            {
+              recipients: ['not-an-email'],
+              subject: 'Invalid notification',
+              body: 'Invalid email should fail'
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Notifications: unknown notification mark-read not found',
+        exec: () =>
+          suite.api.post(
+            `/api/v1/notifications/${UNKNOWN_UUID}/mark-read`,
+            {},
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [404]
+      },
+      {
+        name: 'Config: oversized key rejected',
+        exec: () =>
+          suite.api.put(
+            `/api/v1/config/${longConfigKey}`,
+            {
+              value: '1',
+              category: 'edge'
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Settings: committee cannot toggle modules',
+        exec: () =>
+          suite.api.put(
+            '/api/v1/settings/modules/marketplace/toggle',
+            { enabled: false },
+            context.sessions.COMMITTEE.accessToken
+          ),
+        expected: [403]
+      },
+      {
+        name: 'Analytics: blank report type rejected',
+        exec: () =>
+          suite.api.post(
+            '/api/v1/report-templates',
+            {
+              templateName: `BadTemplate-${suffix}`,
+              reportType: '',
+              description: 'Should fail',
+              queryTemplate: '',
+              parametersJson: '{}',
+              systemTemplate: false
+            },
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [400]
+      },
+      {
+        name: 'Analytics: execute unknown template not found',
+        exec: () =>
+          suite.api.post(
+            `/api/v1/report-templates/${UNKNOWN_UUID}/execute`,
+            {},
+            context.sessions.ADMIN.accessToken
+          ),
+        expected: [404]
+      },
+      {
+        name: 'Analytics: unauthenticated metrics endpoint blocked',
+        exec: () => suite.api.get('/api/v1/analytics/collection-efficiency'),
+        expected: [401, 403]
+      }
+    ]
+
+    for (const testCase of cases) {
+      const response = await testCase.exec()
+      ensureExpectedStatus(response, testCase.expected, 'EDGE', testCase.name)
+    }
+  })
+})


### PR DESCRIPTION
## SG Ticket
- [x] Linked issue in format `SG-XXXX` (example: `Closes #11`)
- Ticket URL: https://github.com/VrushankPatel/ShieldGuard/issues/29

Closes #29

## Change Summary
- What changed:
  - Added `tests/authorization/role-permission-matrix.e2e.test.js`.
  - Added `tests/edge-permutations/domain-edge-permutations.e2e.test.js`.
  - Extended `src/utils/flowHarness.js` with `createRoleSessions` helper.
  - Added scripts:
    - `npm run test:e2e:role-matrix`
    - `npm run test:e2e:edge-permutations`
  - Updated `README.md` scope, structure, run commands, and test catalog.
- Why it changed:
  - To provide full E2E role/permission coverage and deep negative/edge permutation coverage for:
    - Accounting/treasury
    - Staff/payroll
    - Utility monitoring
    - Marketplace
    - Documents/files
    - Notifications
    - Config/settings
    - Analytics/reports
- Scope boundaries (what is intentionally not changed):
  - No SHIELD backend code changes.
  - No CI workflow changes.

## Test Evidence
- [x] Local execution completed
- Commands run:
  - `npm run test:e2e:role-matrix`
  - `npm run test:e2e:edge-permutations`
  - `npx jest --config jest.config.cjs --listTests | wc -l`
- Result summary:
  - New suites pass in this environment.
  - Jest test discovery count increased from 15 to 17 suites.
- Report/log paths (if applicable):
  - Console output.

## Environment and Runtime Notes
- SHIELD target used (dev/stage/local): local
- Env assumptions or required secrets:
  - Uses existing ShieldGuard auth bootstrap behavior (admin creds from env, or root fallback).
- Any non-default runtime settings:
  - None.

## Diagnostics and Risk
- Runtime/container diagnostics reviewed: No
- If failure occurred, artifact/report references:
  - N/A for this change set.
- Residual risks or follow-up actions:
  - If root login is rate-limited/unavailable in a target env, setup-block flow triggers (existing behavior).

## Contributor Checklist
- [x] Branch name follows `feature/SG-XXXX-short-description` (contributors) or approved automation branch naming
- [x] Changes are scoped to the linked ticket
- [x] Tests are deterministic (no random sleeps / flaky timing assumptions)
- [x] No secrets, passwords, or private URLs committed
- [x] Docs updated for behavioral/process changes
